### PR TITLE
修复智能人事离职同步报错

### DIFF
--- a/dingding_hrm/models/add_employee.py
+++ b/dingding_hrm/models/add_employee.py
@@ -63,12 +63,10 @@ class AddDingDingEmployee(models.Model):
         tools.image_resize_images(values)
         return super(AddDingDingEmployee, self).create(values)
 
-    
     def write(self, values):
         tools.image_resize_images(values)
         return super(AddDingDingEmployee, self).write(values)
 
-    
     def add_employee(self):
         """
         智能人事添加企业待入职员工
@@ -116,7 +114,6 @@ class AddDingDingEmployee(models.Model):
         except Exception as e:
             raise UserError(e)
 
-    
     def employees_have_joined(self):
         self.ensure_one()
         raise UserError(_("还没有做这个功能"))

--- a/dingding_hrm/models/employee_roster.py
+++ b/dingding_hrm/models/employee_roster.py
@@ -38,6 +38,7 @@ class EmployeeRoster(models.Model):
         ('正式', '正式'),
         ('离职', '离职'),
         ('未知', '未知'),
+        ('待入职', '待入职'),
     ]
     EMPLOYEETYPES = [
         ('无类型', '无类型'),


### PR DESCRIPTION
1.修复智能人事同步离职员工在某些状态下报错
2.员工状态添加‘待入职’