### PR TITLE
修复获取钉钉日志不准确问题

### DIFF
--- a/dingtalk_attendance/models/attendance_record.py
+++ b/dingtalk_attendance/models/attendance_record.py
@@ -34,8 +34,8 @@ class HrAttendanceRecord(models.Model):
 
     userId = fields.Many2one(comodel_name='hr.employee', string=u'员工', required=True, index=True)
     record_id = fields.Char(string='唯一标识')
-    groupId = fields.Many2one(comodel_name='dingding.simple.groups', string=u'考勤组', index=True)
-    planId = fields.Many2one(comodel_name='hr.dingding.plan', string=u'班次', index=True)
+    groupId = fields.Many2one(comodel_name='dingtalk.simple.groups', string=u'考勤组', index=True)
+    planId = fields.Many2one(comodel_name='hr.dingtalk.plan', string=u'班次', index=True)
     ding_plan_id = fields.Char(string='钉钉排班ID')
     workDate = fields.Date(string=u'工作日', index=True)
     corpId = fields.Char(string='企业ID')

--- a/dingtalk_attendance/models/attendance_result.py
+++ b/dingtalk_attendance/models/attendance_result.py
@@ -39,8 +39,8 @@ class HrAttendanceResult(models.Model):
         ('AUTO_CHECK', '自动打卡')
     ]
     emp_id = fields.Many2one(comodel_name='hr.employee', string=u'员工', required=True, index=True)
-    ding_group_id = fields.Many2one(comodel_name='dingding.simple.groups', string=u'钉钉考勤组')
-    plan_id = fields.Many2one(comodel_name='hr.dingding.plan', string=u'排班')
+    ding_group_id = fields.Many2one(comodel_name='dingtalk.simple.groups', string=u'钉钉考勤组')
+    plan_id = fields.Many2one(comodel_name='hr.dingtalk.plan', string=u'排班')
     ding_plan_id = fields.Char(string='钉钉排班ID')
     record_id = fields.Char(string='唯一标识ID', help="钉钉设置的值为id，odoo中为record_id")
     work_date = fields.Date(string=u'工作日')

--- a/dingtalk_base/tools/dingtalk_api.py
+++ b/dingtalk_base/tools/dingtalk_api.py
@@ -100,6 +100,18 @@ def get_serial_number():
     return False
 
 
+def timestamp_to_utc_date(timeNum):
+    """
+    将13位时间戳转换为时间utc=0
+    :param timeNum:
+    :return:
+    """
+    timeStamp = float(timeNum / 1000)
+    timeArray = time.gmtime(timeStamp)
+    otherStyleTime = time.strftime("%Y-%m-%d %H:%M:%S", timeArray)
+    return otherStyleTime
+
+
 def timestamp_to_local_date(time_num):
     """
     将13位毫秒时间戳转换为本地日期(+8h)
@@ -122,6 +134,19 @@ def datetime_to_stamp(time_num):
     :return: date_stamp
     """
     date_str = fields.Datetime.to_string(time_num)
+    date_stamp = time.mktime(time.strptime(date_str, "%Y-%m-%d %H:%M:%S"))
+    date_stamp = date_stamp * 1000
+    return int(date_stamp)
+
+
+def datetime_to_local_stamp(date_time):
+    """
+    将utc=0的时间转成13位时间戳(本地时间戳：+8H)
+    :param time_num:
+    :return: date_stamp
+    """
+    to_local_datetime = fields.Datetime.context_timestamp(request, date_time)
+    date_str = fields.Datetime.to_string(to_local_datetime)
     date_stamp = time.mktime(time.strptime(date_str, "%Y-%m-%d %H:%M:%S"))
     date_stamp = date_stamp * 1000
     return int(date_stamp)

--- a/dingtalk_hr/wizard/synchronous.py
+++ b/dingtalk_hr/wizard/synchronous.py
@@ -114,7 +114,8 @@ class DingTalkHrSynchronous(models.TransientModel):
         """
         departments = self.env['hr.department'].sudo().search([('ding_id', '!=', ''), ('active', '!=', False)])
         client = dingtalk_api.get_client()
-        for department in departments.with_progress(msg="同步部门员工"):
+        # for department in departments.with_progress(msg="同步部门员工"):
+        for department in departments:
             emp_offset = 0
             emp_size = 100
             while True:


### PR DESCRIPTION
1.修复获取日志游标取值错误
（官方文档描述与实际有出入,实际上当has_more=True时，cursor=next_cursor）
2.修复日志获取时间段时差问题
起因：钉钉上的时间戳及日期是带时区的，存入odoo系统的时间是要不带时区的。
为此，在dingtalk_api增加2个函数：
1）将13位时间戳转换为时间utc=0
def timestamp_to_utc_date(timeNum)
2）将utc=0的时间转成13位时间戳(本地时间戳：+8H)
def datetime_to_local_stamp(date_time)