### PR TITLE
完善从钉钉获取请假列表若干问题

### DIFF
--- a/dingtalk_attendance/wizard/leaves_list.py
+++ b/dingtalk_attendance/wizard/leaves_list.py
@@ -24,49 +24,52 @@ class HrLeavesListTran(models.TransientModel):
         """
         self.ensure_one()
         din_client = dingtalk_api.get_client()
-        offset = 0
-        size = 20
         user_list = list()
         for emp in self.user_ids:
             if emp.ding_id:
                 user_list.append(emp.ding_id)
         user_list = dingtalk_api.list_cut(user_list, 100)
+        date_list = dingtalk_api.day_cut(self.start_time, self.end_time, 180)
         for u in user_list:
             user_str = ",".join(u)
-            while True:
-                try:
-                    result = din_client.attendance.getleavestatus(
-                        user_str, self.start_time, self.end_time, offset=offset, size=size)
-                    logging.info(">>>查询请假状态返回结果%s", result)
-                    leave_status = result['leave_status']
-                    if leave_status:
-                        leave_list = list()
-                        for leave in leave_status.get('leave_status_v_o'):
-                            leave_data = {
-                                'start_time_stamp': leave['start_time'],
-                                'end_time_stamp': leave['end_time'],
-                                'duration_unit': leave['duration_unit'],
-                                'duration_percent': leave['duration_percent'] / 100,
-                                'end_time': dingtalk_api.timestamp_to_local_date(leave['end_time']),
-                                'start_time': dingtalk_api.timestamp_to_local_date(leave['start_time']),
-                            }
-                            employee = self.env['hr.employee'].search([('ding_id', '=', leave['userid'])], limit=1)
-                            leave_data.update({
-                                'user_id': employee.id if employee else False,
-                                'din_jobnumber': employee.din_jobnumber if employee else False,
-                            })
-                            leave_list.append(leave_data)
-                            # 删除已存在的请假记录
-                            domain = [('start_time_stamp', '=', leave['start_time']), ('user_id', '=', employee.id), ('end_time_stamp', '=', leave['end_time'])]
-                            self.env['hr.leaves.list'].search(domain).unlink()
-                        # 批量存储记录
-                        self.env['hr.leaves.list'].create(leave_list)
-                    if not result['has_more']:
-                        break
-                    else:
-                        offset += size
-                except Exception as e:
-                    raise UserError(e)
+            for date_arr in date_list:
+                offset = 0
+                size = 20
+                while True:
+                    try:
+                        result = din_client.attendance.getleavestatus(
+                            user_str, fields.Datetime.from_string(date_arr[0]), fields.Datetime.from_string(date_arr[1]), offset=offset, size=size)
+                        logging.info(">>>查询请假状态返回结果%s", result)
+                        leave_status = result['leave_status']
+                        if leave_status:
+                            leave_list = list()
+                            for leave in leave_status.get('leave_status_v_o'):
+                                leave_data = {
+                                    'start_time_stamp': leave['start_time'],
+                                    'end_time_stamp': leave['end_time'],
+                                    'duration_unit': leave['duration_unit'],
+                                    'duration_percent': leave['duration_percent'] / 100,
+                                    'end_time': dingtalk_api.timestamp_to_utc_date(leave['end_time']),
+                                    'start_time': dingtalk_api.timestamp_to_utc_date(leave['start_time']),
+                                }
+                                employee = self.env['hr.employee'].search([('ding_id', '=', leave['userid'])], limit=1)
+                                leave_data.update({
+                                    'user_id': employee.id if employee else False,
+                                    'din_jobnumber': employee.din_jobnumber if employee else False,
+                                })
+                                leave_list.append(leave_data)
+                                # 删除已存在的请假记录
+                                domain = [('start_time_stamp', '=', leave['start_time']), ('user_id',
+                                                                                        '=', employee.id), ('end_time_stamp', '=', leave['end_time'])]
+                                self.env['hr.leaves.list'].search(domain).unlink()
+                            # 批量存储记录
+                            self.env['hr.leaves.list'].create(leave_list)
+                        if not result['has_more']:
+                            break
+                        else:
+                            offset += size
+                    except Exception as e:
+                        raise UserError(e)
         return {'type': 'ir.actions.act_window_close'}
 
     @api.onchange('is_all_emp')

--- a/dingtalk_base/tools/dingtalk_api.py
+++ b/dingtalk_base/tools/dingtalk_api.py
@@ -152,6 +152,17 @@ def datetime_to_local_stamp(date_time):
     return int(date_stamp)
 
 
+def datetime_to_local_date(date_time):
+    """
+    将utc=0时间格式转换为本地时间格式(+8h)
+    :param time_num:
+    :return: string datetime
+    """
+    to_datetime = fields.Datetime.from_string(date_time)
+    to_local_datetime = fields.Datetime.context_timestamp(request, to_datetime)  # 将原生的datetime值(无时区)转换为具体时区的datetime
+    return to_local_datetime
+
+
 def get_user_info_by_code(code):
     """
     根据扫码或账号密码登录返回的code获取用户信息


### PR DESCRIPTION
1.修复获取钉钉请假表时间显示错误
为此在api增加将utc时间转本地时间格式的函数
2.修复获取请假数据时间段超过180天报错