### PR TITLE
完善钉钉日志获取

### DIFF
--- a/dingtalk_base/tools/dingtalk_api.py
+++ b/dingtalk_base/tools/dingtalk_api.py
@@ -145,7 +145,8 @@ def datetime_to_local_stamp(date_time):
     :param time_num:
     :return: date_stamp
     """
-    to_local_datetime = fields.Datetime.context_timestamp(request, date_time)
+    to_datetime = fields.Datetime.from_string(date_time)
+    to_local_datetime = fields.Datetime.context_timestamp(request, to_datetime)
     date_str = fields.Datetime.to_string(to_local_datetime)
     date_stamp = time.mktime(time.strptime(date_str, "%Y-%m-%d %H:%M:%S"))
     date_stamp = date_stamp * 1000

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -57,8 +57,8 @@ class DingTalkReport(models.Model):
     has_thinking_today_performance = fields.Selection(related="category_id.has_thinking_today_performance")
     has_date = fields.Selection(related="category_id.has_date")
 
-    report_id = fields.Char(string='唯一ID')
-    employee_id = fields.Many2one(comodel_name='hr.employee', string=u'员工')
+    report_id = fields.Char(string='日志ID')
+    employee_id = fields.Many2one(comodel_name='hr.employee', string=u'填报人', default=lambda self: self.env.user.employee_id)
     report_time = fields.Datetime(string=u'日志时间', default=fields.datetime.now())
 
     def _compute_attachment_number(self):

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -57,7 +57,7 @@ class DingTalkReport(models.Model):
     has_thinking_today_performance = fields.Selection(related="category_id.has_thinking_today_performance")
     has_date = fields.Selection(related="category_id.has_date")
 
-    report_id = fields.Char(string='日志ID')
+    report_id = fields.Char(string='钉钉日志ID')
     employee_id = fields.Many2one(comodel_name='hr.employee', string=u'填报人', default=lambda self: self.env.user.employee_id)
     report_time = fields.Datetime(string=u'填报时间', default=fields.Datetime.now())
 

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -60,7 +60,8 @@ class DingTalkReport(models.Model):
     report_id = fields.Char(string='钉钉日志ID')
     employee_id = fields.Many2one(comodel_name='hr.employee', string=u'填报人', default=lambda self: self.env.user.employee_id)
     report_time = fields.Datetime(string=u'填报时间', default=fields.Datetime.now())
-    image_ids = fields.One2many(comodel_name='dingtalk.report.image', inverse_name='rep_id', string=u'照片列表')
+    image_ids = fields.One2many(comodel_name='dingtalk.report.image', inverse_name='report_id', string=u'图片列表', ondelete='cascade')
+    image1_url = fields.Char(string='图片1链接')
 
     def _compute_attachment_number(self):
         domain = [('res_model', '=', 'dingtalk.report.report'), ('res_id', 'in', self.ids)]
@@ -110,10 +111,12 @@ class DingTalkReport(models.Model):
 
 class DingTalkReportImages(models.Model):
     _name = 'dingtalk.report.image'
-    _description = "日志照片列表"
-    _rec_name = 'report_id'
+    _description = "日志图片"
+    _rec_name = 'report_time'
 
     category_id = fields.Many2one('dingtalk.report.category', string="日志类型")
-    report_id = fields.Char(string='钉钉日志ID')
-    report_image_url = fields.Text(string='照片链接')
-    rep_id = fields.Many2one('dingtalk.report.report', string='日志ID')
+    report_image_url = fields.Text(string='图片链接')
+    dingtalk_report_id = fields.Text(string='钉钉日志ID')
+    report_time = fields.Datetime(string=u'填报时间', default=fields.Datetime.now())
+    report_id = fields.Many2one('dingtalk.report.report', string='日志ID', ondelete='cascade')
+

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -60,6 +60,7 @@ class DingTalkReport(models.Model):
     report_id = fields.Char(string='钉钉日志ID')
     employee_id = fields.Many2one(comodel_name='hr.employee', string=u'填报人', default=lambda self: self.env.user.employee_id)
     report_time = fields.Datetime(string=u'填报时间', default=fields.Datetime.now())
+    image_ids = fields.One2many(comodel_name='dingtalk.report.image', inverse_name='rep_id', string=u'照片列表')
 
     def _compute_attachment_number(self):
         domain = [('res_model', '=', 'dingtalk.report.report'), ('res_id', 'in', self.ids)]
@@ -105,3 +106,14 @@ class DingTalkReport(models.Model):
             emp_list.append(emp.name)
             emp_conut.append(report_count)
         return {'sum_count': report_sum_count, 'emp_list': emp_list, 'emp_conut': emp_conut}
+
+
+class DingTalkReportImages(models.Model):
+    _name = 'dingtalk.report.image'
+    _description = "日志照片列表"
+    _rec_name = 'report_id'
+
+    category_id = fields.Many2one('dingtalk.report.category', string="日志类型")
+    report_id = fields.Char(string='钉钉日志ID')
+    report_image_url = fields.Text(string='照片链接')
+    rep_id = fields.Many2one('dingtalk.report.report', string='日志ID')

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -113,6 +113,7 @@ class DingTalkReportImages(models.Model):
     _name = 'dingtalk.report.image'
     _description = "日志图片"
     _rec_name = 'report_time'
+    _order = 'report_time'
 
     category_id = fields.Many2one('dingtalk.report.category', string="日志类型")
     report_image_url = fields.Text(string='图片链接')

--- a/dingtalk_report/models/report_report.py
+++ b/dingtalk_report/models/report_report.py
@@ -16,7 +16,7 @@ class DingTalkReport(models.Model):
 
     name = fields.Char(string='主题')
     category_id = fields.Many2one('dingtalk.report.category', string="日志类型", required=True)
-    date = fields.Datetime(string="日期", default=fields.date.today())
+    date = fields.Date(string="日期", default=fields.Date.today())
     attachment_number = fields.Integer('附件数', compute='_compute_attachment_number')
     today_work = fields.Text(string=u'今日完成工作')
     no_compute_work = fields.Text(string=u'未完成工作')
@@ -59,7 +59,7 @@ class DingTalkReport(models.Model):
 
     report_id = fields.Char(string='日志ID')
     employee_id = fields.Many2one(comodel_name='hr.employee', string=u'填报人', default=lambda self: self.env.user.employee_id)
-    report_time = fields.Datetime(string=u'日志时间', default=fields.datetime.now())
+    report_time = fields.Datetime(string=u'填报时间', default=fields.Datetime.now())
 
     def _compute_attachment_number(self):
         domain = [('res_model', '=', 'dingtalk.report.report'), ('res_id', 'in', self.ids)]

--- a/dingtalk_report/security/ir.model.access.csv
+++ b/dingtalk_report/security/ir.model.access.csv
@@ -4,4 +4,4 @@ access_dingtalk_report_category_manage_group,dingtalk.report.category.manage,mod
 access_dingtalk_report_report,dingtalk.report.report,model_dingtalk_report_report,dingtalk_report.user_group,1,1,1,1
 access_dingtalk_report_template,dingtalk.report.template,model_dingtalk_report_template,dingtalk_report.user_group,1,0,0,0
 access_dingtalk_report_template_manage_group,dingtalk.report.template.manage,model_dingtalk_report_template,dingtalk_report.manage_group,1,1,1,1
-
+access_dingtalk_report_image,dingtalk.report.image,model_dingtalk_report_image,dingtalk_report.user_group,1,1,1,1

--- a/dingtalk_report/views/assets.xml
+++ b/dingtalk_report/views/assets.xml
@@ -17,13 +17,13 @@
 
     <menuitem name="日志" id="report_root_menu" web_icon="dingtalk_report,static/description/icon.png" sequence="16"/>
 
-    <menuitem name="钉钉" id="dingtalk_report_root_menu" parent="report_root_menu" sequence="20"/>
+    <menuitem name="钉钉日志" id="dingtalk_report_root_menu" parent="report_root_menu" sequence="20"/>
 
     <record id="dingtalk_report_panel_action" model="ir.actions.client">
         <field name="name">日志统计</field>
         <field name="tag">dingtalk_report_panel</field>
     </record>
 
-    <menuitem name="日志统计" id="dingtalk_report_panel_menu" parent="report_root_menu" sequence="25" action="dingtalk_report_panel_action"/>
+    <menuitem name="日志统计" id="dingtalk_report_panel_menu" parent="report_root_menu" sequence="5" action="dingtalk_report_panel_action"/>
 
 </odoo>

--- a/dingtalk_report/views/report_category.xml
+++ b/dingtalk_report/views/report_category.xml
@@ -75,7 +75,7 @@
     </record>
 
     <record id="dingtalk_report_category_action" model="ir.actions.act_window">
-        <field name="name">日志</field>
+        <field name="name">日志类型</field>
         <field name="res_model">dingtalk.report.category</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="help" type="html">
@@ -85,7 +85,7 @@
         </field>
     </record>
 
-    <menuitem id="dingtalk_report_category_menu" name="日志" parent="report_root_menu" sequence="2" action="dingtalk_report_category_action"/>
+    <menuitem id="dingtalk_report_category_menu" name="日志类型" parent="report_root_menu" sequence="2" action="dingtalk_report_category_action"/>
 
     <record id="dingtalk_report_category_view_kanban" model="ir.ui.view">
         <field name="name">dingtalk.report.category.views.kanban</field>

--- a/dingtalk_report/views/report_category.xml
+++ b/dingtalk_report/views/report_category.xml
@@ -111,7 +111,7 @@
                                 </p>
                                 <div class="oe_module_action" t-if="!selection_mode">
                                     <button type="object" class="btn btn-primary btn-sm" name="create_report" context="{'category_id':'active_id'}">写日志</button>
-                                    <button type="object" class="btn btn-sm btn-secondary float-right" name="get_dingtalk_report_list">钉钉日志</button>
+                                    <button type="object" class="btn btn-sm btn-secondary float-right" name="get_dingtalk_report_list" context="{'default_category_id':active_id}" >钉钉日志</button>
                                 </div>
                             </div>
                         </div>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -114,7 +114,7 @@
                         <page string="日志照片" name="info_pic">
                             <field name="image_ids" options="{'no_open': True}">
                                 <tree editable="top">
-                                    <field name="report_image_url" widget="image_url"/>
+                                    <field name="report_image_url" widget="image_url" width="200px" height="200px"/>
                                 </tree>
                             </field>
                         </page>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -111,7 +111,7 @@
                             <field name="thinking_today_performance" attrs="{'invisible':[('has_thinking_today_performance', '==','no')], 'required': [('has_thinking_today_performance','==','required')]}"/>
                             </group>
                         </page>
-                        <page string="日志照片" name="info_pic">
+                        <page string="日志图片" name="info_pic">
                             <field name="image_ids" options="{'no_open': True}">
                                 <tree editable="top">
                                     <field name="report_image_url" widget="image_url" width="200px" height="200px"/>
@@ -150,36 +150,44 @@
                 <field name="create_date"/>
                 <field name="employee_id"/>
                 <field name="report_time"/>
+                <field name="image1_url"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click container">
-                            <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
-                                <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" href="#" aria-label="Dropdown menu" title="菜单">
-                                    <span class="fa fa-ellipsis-v"/>
-                                </a>
-                                <div class="dropdown-menu" role="menu">
-                                    <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">编辑</a>
-                                    <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">删除</a>
-                                </div>
+                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
+                            <div class="o_kanban_image_fill_left d-none d-md-block">
+                                <t t-if="record.image1_url.raw_value"><field name="image1_url" widget="image_url" width="100px" height="100px"/></t>
                             </div>
-                            <div class="oe_kanban_content">
-                                <div>
-                                    <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                </div>
-
-                                <div class="text-muted o_kanban_record_subtitle">
-                                    <field name="category_id"/>-<field name="employee_id"/>
-                                </div>
-
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <img t-att-src="kanban_image('hr.employee', 'image_1920', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="oe_kanban_avatar"/>
+                            <div class="oe_kanban_details">
+                                <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
+                                    <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" href="#" aria-label="Dropdown menu" title="菜单">
+                                        <span class="fa fa-ellipsis-v"/>
+                                    </a>
+                                    <div class="dropdown-menu" role="menu">
+                                        <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">编辑</a>
+                                        <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">删除</a>
                                     </div>
                                 </div>
-                            </div>
+                                <div class="oe_kanban_content">
+                                    <div>
+                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
+                                    </div>
+
+                                    <div class="text-muted o_kanban_record_subtitle">
+                                        <ul>
+                                            <li><field name="category_id"/>-<field name="employee_id"/></li>
+                                            <li><field name="report_time"/></li>
+                                        </ul>
+                                    </div>
+                                    <div class="o_kanban_record_bottom">
+                                        <div class="oe_kanban_bottom_left">
+                                            <field name="activity_ids" widget="kanban_activity"/>
+                                        </div>
+                                        <div class="oe_kanban_bottom_right">
+                                            <img t-att-src="kanban_image('hr.employee', 'image_1920', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="oe_kanban_avatar"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>   
                         </div>
                     </t>
                 </templates>
@@ -199,11 +207,50 @@
         </field>
     </record>
 
+    <menuitem id="dingtalk_report_report_menu" parent="report_root_menu" name="日志列表" action="dingtalk_report_report_action" sequence="3"/>
+
+    <!-- 以下是日志图片相关视图 -->
+    <record id="dingtalk_report_image_view_tree" model="ir.ui.view">
+        <field name="name">dingtalk.report.image.view.tree</field>
+        <field name="model">dingtalk.report.image</field>
+        <field name="priority">10</field>
+        <field name="arch" type="xml">
+            <tree create="0">
+                <field name="category_id"/>
+                <field name="report_id"/>
+                <field name="dingtalk_report_id"/>
+                <field name="report_time"/>
+                <field name="report_image_url" widget="image_url" class="oe_image_small" width="80px" height="80px"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="dingtalk_report_image_view_search" model="ir.ui.view">
+        <field name="name">dingtalk.report.image.search</field>
+        <field name="model">dingtalk.report.image</field>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="report_id"/>
+                <field name="category_id"/>
+                <field name="dingtalk_report_id"/>
+                <field name="report_time"/>
+                <field name="create_uid" string="创建人"/>
+                <field name="create_date" string="创建日期"/>
+                <group expand="0" string="分组">
+                    <filter name="group_by_category_id" string="类型" context="{'group_by':'category_id'}"/>
+                    <filter name="group_by_dingtalk_report_id" string="日志" context="{'group_by':'dingtalk_report_id'}"/>
+                    <filter name="group_by_report_time" string="填报时间" context="{'group_by':'report_time'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
     <record id="dingtalk_report_image_view_form" model="ir.ui.view">
         <field name="name">dingtalk.report.iamge.view.form</field>
         <field name="model">dingtalk.report.image</field>
         <field name="arch" type="xml">
-            <form string="日志照片" create="0">
+            <form string="日志图片" create="0">
                 <sheet>
                     <field name="report_image_url" widget="image_url"/>
                 </sheet>  
@@ -211,6 +258,52 @@
         </field>
     </record>
 
-    <menuitem id="dingtalk_report_report_menu" parent="report_root_menu" name="所有日志" action="dingtalk_report_report_action" sequence="5"/>
+    <record id="dingtalk_report_image_action" model="ir.actions.act_window">
+        <field name="name">日志图片</field>
+        <field name="res_model">dingtalk.report.image</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            没有图片~
+          </p>
+        </field>
+    </record>
+
+    <menuitem id="dingtalk_report_image_menu" name="日志图片" parent="report_root_menu" sequence="4" action="dingtalk_report_image_action"/>
+
+    <record id="dingtalk_report_image_view_kanban" model="ir.ui.view">
+        <field name="name">dingtalk.report.image.views.kanban</field>
+        <field name="model">dingtalk.report.image</field>
+        <field name="arch" type="xml">
+            <kanban class="o_modules_kanban">
+                <field name="report_id"/>
+                <field name="dingtalk_report_id"/>
+                <field name="id"/>
+                <field name="report_image_url"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
+                            <div class="o_kanban_image_fill_left d-none d-md-block">
+                                <field name="report_image_url" widget="image_url" width="100px" height="100px"/>
+                            </div>
+                            <div class="oe_kanban_details">
+                                <div class="o_kanban_record_top">
+                                    <div class="o_kanban_record_headings">
+                                        <strong class="o_kanban_record_title">
+                                            <span t-if="record.category_id.raw_value"><field name="category_id"/></span>
+                                        </strong>
+                                    </div>
+                                </div>
+                                <ul>
+                                   <li><field name="report_id"/></li>
+                                   <li><field name="report_time"/></li>
+                               </ul>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
 
 </odoo>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -10,6 +10,7 @@
                 <field name="name"/>
                 <field name="category_id"/>
                 <field name="date"/>
+                <field name="report_id"/>
                 <field name="employee_id"/>
                 <field name="report_time"/>
             </tree>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -109,14 +109,12 @@
                             <field name="monthly_ct_performance" attrs="{'invisible':[('has_monthly_ct_performance', '==','no')], 'required': [('has_monthly_ct_performance','==','required')]}"/>
                             <field name="month_pt_performance" attrs="{'invisible':[('has_month_pt_performance', '==','no')], 'required': [('has_month_pt_performance','==','required')]}"/>
                             <field name="thinking_today_performance" attrs="{'invisible':[('has_thinking_today_performance', '==','no')], 'required': [('has_thinking_today_performance','==','required')]}"/>
-                            </group>
-                        </page>
-                        <page string="日志图片" name="info_pic">
                             <field name="image_ids" options="{'no_open': True}">
                                 <tree editable="top">
                                     <field name="report_image_url" widget="image_url" width="200px" height="200px"/>
                                 </tree>
                             </field>
+                            </group>
                         </page>
                     </notebook>
                     <group>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -115,7 +115,7 @@
                             <field name="employee_id" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
                         </group>
                         <group>
-                            <field name="report_time" widget="datetime"/>
+                            <field name="report_time"/>
                         </group>
                     </group>
                 </sheet>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -35,6 +35,8 @@
                 <separator/>
                 <group expand="0" string="分组">
                     <filter name="group_by_category_id" string="类型" context="{'group_by':'category_id'}"/>
+                    <filter name="group_by_employee_id" string="填报人" context="{'group_by':'employee_id'}"/>
+                    <filter name="group_by_report_time" string="填报时间" context="{'group_by':'report_time'}"/>
                 </group>
             </search>
         </field>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -114,7 +114,7 @@
                         <page string="日志照片" name="info_pic">
                             <field name="image_ids" options="{'no_open': True}">
                                 <tree editable="top">
-                                    <field name="report_image_url"/>
+                                    <field name="report_image_url" widget="image_url"/>
                                 </tree>
                             </field>
                         </page>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -31,7 +31,7 @@
                 <field name="create_uid" string="创建人"/>
                 <field name="create_date" string="创建日期"/>
                 <separator/>
-                    <filter string="我的日志" name="filter_my_report" domain="[('create_uid', '=', uid)]"/>
+                <filter string="我的日志" name="filter_my_report" domain="[('create_uid', '=', uid)]"/>
                 <separator/>
                 <group expand="0" string="分组">
                     <filter name="group_by_category_id" string="类型" context="{'group_by':'category_id'}"/>
@@ -87,33 +87,40 @@
                     <notebook>
                         <page string="日志详情" name="info">
                             <group>
-                            <field name="today_work" attrs="{'invisible':[('has_today_work', '==','no')], 'required': [('has_today_work','==','required')]}"/>
-                            <field name="no_compute_work" attrs="{'invisible':[('has_no_compute_work', '==','no')], 'required': [('has_no_compute_work','==','required')]}"/>
+                                <field name="today_work" attrs="{'invisible':[('has_today_work', '==','no')], 'required': [('has_today_work','==','required')]}"/>
+                                <field name="no_compute_work" attrs="{'invisible':[('has_no_compute_work', '==','no')], 'required': [('has_no_compute_work','==','required')]}"/>
 
-                            <field name="week_compute" attrs="{'invisible':[('has_week_compute', '==','no')], 'required': [('has_week_compute','==','required')]}"/>
-                            <field name="week_summary" attrs="{'invisible':[('has_week_summary', '==','no')], 'required': [('has_week_summary','==','required')]}"/>
-                            <field name="next_week_plan" attrs="{'invisible':[('has_next_week_plan', '==','no')], 'required': [('has_next_week_plan','==','required')]}"/>
+                                <field name="week_compute" attrs="{'invisible':[('has_week_compute', '==','no')], 'required': [('has_week_compute','==','required')]}"/>
+                                <field name="week_summary" attrs="{'invisible':[('has_week_summary', '==','no')], 'required': [('has_week_summary','==','required')]}"/>
+                                <field name="next_week_plan" attrs="{'invisible':[('has_next_week_plan', '==','no')], 'required': [('has_next_week_plan','==','required')]}"/>
 
-                            <field name="month_work" attrs="{'invisible':[('has_month_work', '==','no')], 'required': [('has_month_work','==','required')]}"/>
-                            <field name="month_summary" attrs="{'invisible':[('has_month_summary', '==','no')], 'required': [('has_month_summary','==','required')]}"/>
-                            <field name="next_month_plan" attrs="{'invisible':[('has_next_month_plan', '==','no')], 'required': [('has_next_month_plan','==','required')]}"/>
+                                <field name="month_work" attrs="{'invisible':[('has_month_work', '==','no')], 'required': [('has_month_work','==','required')]}"/>
+                                <field name="month_summary" attrs="{'invisible':[('has_month_summary', '==','no')], 'required': [('has_month_summary','==','required')]}"/>
+                                <field name="next_month_plan" attrs="{'invisible':[('has_next_month_plan', '==','no')], 'required': [('has_next_month_plan','==','required')]}"/>
 
-                            <field name="coordination_work" attrs="{'invisible':[('has_coordination_work', '==','no')], 'required': [('has_coordination_work','==','required')]}"/>
-                            <field name="visit_partner" attrs="{'invisible':[('has_visit_partner', '==','no')], 'required': [('has_visit_partner','==','required')]}" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
-                            <field name="visit_type" attrs="{'invisible':[('has_visit_type', '==','no')], 'required': [('has_visit_type','==','required')]}"/>
-                            <field name="visit_matter" attrs="{'invisible':[('has_visit_matter', '==','no')], 'required': [('has_visit_matter','==','required')]}"/>
-                            <field name="visit_result" attrs="{'invisible':[('has_visit_result', '==','no')], 'required': [('has_visit_result','==','required')]}"/>
+                                <field name="coordination_work" attrs="{'invisible':[('has_coordination_work', '==','no')], 'required': [('has_coordination_work','==','required')]}"/>
+                                <field name="visit_partner" attrs="{'invisible':[('has_visit_partner', '==','no')], 'required': [('has_visit_partner','==','required')]}" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
+                                <field name="visit_type" attrs="{'invisible':[('has_visit_type', '==','no')], 'required': [('has_visit_type','==','required')]}"/>
+                                <field name="visit_matter" attrs="{'invisible':[('has_visit_matter', '==','no')], 'required': [('has_visit_matter','==','required')]}"/>
+                                <field name="visit_result" attrs="{'invisible':[('has_visit_result', '==','no')], 'required': [('has_visit_result','==','required')]}"/>
 
-                            <field name="today_urnover_performance" attrs="{'invisible':[('has_today_urnover_performance', '==','no')], 'required': [('has_today_urnover_performance','==','required')]}"/>
-                            <field name="today_partner_performance" attrs="{'invisible':[('has_today_partner_performance', '==','no')], 'required': [('has_today_partner_performance','==','required')]}"/>
-                            <field name="monthly_ct_performance" attrs="{'invisible':[('has_monthly_ct_performance', '==','no')], 'required': [('has_monthly_ct_performance','==','required')]}"/>
-                            <field name="month_pt_performance" attrs="{'invisible':[('has_month_pt_performance', '==','no')], 'required': [('has_month_pt_performance','==','required')]}"/>
-                            <field name="thinking_today_performance" attrs="{'invisible':[('has_thinking_today_performance', '==','no')], 'required': [('has_thinking_today_performance','==','required')]}"/>
-                            <field name="image_ids" options="{'no_open': True}">
-                                <tree editable="top">
-                                    <field name="report_image_url" widget="image_url" width="200px" height="200px"/>
-                                </tree>
-                            </field>
+                                <field name="today_urnover_performance" attrs="{'invisible':[('has_today_urnover_performance', '==','no')], 'required': [('has_today_urnover_performance','==','required')]}"/>
+                                <field name="today_partner_performance" attrs="{'invisible':[('has_today_partner_performance', '==','no')], 'required': [('has_today_partner_performance','==','required')]}"/>
+                                <field name="monthly_ct_performance" attrs="{'invisible':[('has_monthly_ct_performance', '==','no')], 'required': [('has_monthly_ct_performance','==','required')]}"/>
+                                <field name="month_pt_performance" attrs="{'invisible':[('has_month_pt_performance', '==','no')], 'required': [('has_month_pt_performance','==','required')]}"/>
+                                <field name="thinking_today_performance" attrs="{'invisible':[('has_thinking_today_performance', '==','no')], 'required': [('has_thinking_today_performance','==','required')]}"/>
+                                <field name="image_ids" options="{'no_open': True}">
+                                    <kanban quick_create="false" create="true" class="o_modules_kanban">
+                                        <field name="report_image_url"/>
+                                        <templates>
+                                            <t t-name="kanban-box">
+                                                <div class="oe_kanban_global_click">
+                                                    <field name="report_image_url" widget="image_url" width="100px" height="100px"/>
+                                                </div>
+                                            </t>
+                                        </templates>
+                                    </kanban>
+                                </field>
                             </group>
                         </page>
                     </notebook>
@@ -140,7 +147,7 @@
         <field name="name">dingtalk.report.report.view.kanban</field>
         <field name="model">dingtalk.report.report</field>
         <field name="arch" type="xml">
-            <kanban create="false" class="o_modules_kanban" >
+            <kanban create="false" class="o_modules_kanban">
                 <field name="name"/>
                 <field name="category_id"/>
                 <field name="date"/>
@@ -153,7 +160,9 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
                             <div class="o_kanban_image_fill_left d-none d-md-block">
-                                <t t-if="record.image1_url.raw_value"><field name="image1_url" widget="image_url" width="100px" height="100px"/></t>
+                                <t t-if="record.image1_url.raw_value">
+                                    <field name="image1_url" widget="image_url" width="100px" height="100px"/>
+                                </t>
                             </div>
                             <div class="oe_kanban_details">
                                 <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
@@ -167,13 +176,20 @@
                                 </div>
                                 <div class="oe_kanban_content">
                                     <div>
-                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
+                                        <strong class="o_kanban_record_title">
+                                            <field name="name"/>
+                                        </strong>
                                     </div>
 
                                     <div class="text-muted o_kanban_record_subtitle">
                                         <ul>
-                                            <li><field name="category_id"/>-<field name="employee_id"/></li>
-                                            <li><field name="report_time"/></li>
+                                            <li>
+                                                <field name="category_id"/>
+-                                                <field name="employee_id"/>
+                                            </li>
+                                            <li>
+                                                <field name="report_time"/>
+                                            </li>
                                         </ul>
                                     </div>
                                     <div class="o_kanban_record_bottom">
@@ -185,7 +201,7 @@
                                         </div>
                                     </div>
                                 </div>
-                            </div>   
+                            </div>
                         </div>
                     </t>
                 </templates>
@@ -193,15 +209,15 @@
         </field>
     </record>
 
-     <record id="dingtalk_report_report_action" model="ir.actions.act_window">
+    <record id="dingtalk_report_report_action" model="ir.actions.act_window">
         <field name="name">日志列表</field>
         <field name="res_model">dingtalk.report.report</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="context">{'search_default_group_by_category_id': True}</field>
         <field name="help" type="html">
-          <p class="o_view_nocontent_smiling_face">
+            <p class="o_view_nocontent_smiling_face">
             日志列表
-          </p>
+            </p>
         </field>
     </record>
 
@@ -233,8 +249,6 @@
                 <field name="category_id"/>
                 <field name="dingtalk_report_id"/>
                 <field name="report_time"/>
-                <field name="create_uid" string="创建人"/>
-                <field name="create_date" string="创建日期"/>
                 <group expand="0" string="分组">
                     <filter name="group_by_category_id" string="类型" context="{'group_by':'category_id'}"/>
                     <filter name="group_by_dingtalk_report_id" string="日志" context="{'group_by':'dingtalk_report_id'}"/>
@@ -251,7 +265,7 @@
             <form string="日志图片">
                 <sheet>
                     <field name="report_image_url" widget="image_url"/>
-                </sheet>  
+                </sheet>
             </form>
         </field>
     </record>
@@ -261,9 +275,9 @@
         <field name="res_model">dingtalk.report.image</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="help" type="html">
-          <p class="o_view_nocontent_smiling_face">
+            <p class="o_view_nocontent_smiling_face">
             没有图片~
-          </p>
+            </p>
         </field>
     </record>
 
@@ -288,14 +302,20 @@
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings">
                                         <strong class="o_kanban_record_title">
-                                            <span t-if="record.category_id.raw_value"><field name="category_id"/></span>
+                                            <span t-if="record.category_id.raw_value">
+                                                <field name="category_id"/>
+                                            </span>
                                         </strong>
                                     </div>
                                 </div>
                                 <ul>
-                                   <li><field name="report_id"/></li>
-                                   <li><field name="report_time"/></li>
-                               </ul>
+                                    <li>
+                                        <field name="report_id"/>
+                                    </li>
+                                    <li>
+                                        <field name="report_time"/>
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                     </t>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -248,7 +248,7 @@
         <field name="name">dingtalk.report.iamge.view.form</field>
         <field name="model">dingtalk.report.image</field>
         <field name="arch" type="xml">
-            <form string="日志图片" create="0">
+            <form string="日志图片">
                 <sheet>
                     <field name="report_image_url" widget="image_url"/>
                 </sheet>  

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -199,6 +199,18 @@
         </field>
     </record>
 
+    <record id="dingtalk_report_image_view_form" model="ir.ui.view">
+        <field name="name">dingtalk.report.iamge.view.form</field>
+        <field name="model">dingtalk.report.image</field>
+        <field name="arch" type="xml">
+            <form string="日志照片" create="0">
+                <sheet>
+                    <field name="report_image_url" widget="image_url"/>
+                </sheet>  
+            </form>
+        </field>
+    </record>
+
     <menuitem id="dingtalk_report_report_menu" parent="report_root_menu" name="所有日志" action="dingtalk_report_report_action" sequence="5"/>
 
 </odoo>

--- a/dingtalk_report/views/report_report.xml
+++ b/dingtalk_report/views/report_report.xml
@@ -111,6 +111,13 @@
                             <field name="thinking_today_performance" attrs="{'invisible':[('has_thinking_today_performance', '==','no')], 'required': [('has_thinking_today_performance','==','required')]}"/>
                             </group>
                         </page>
+                        <page string="日志照片" name="info_pic">
+                            <field name="image_ids" options="{'no_open': True}">
+                                <tree editable="top">
+                                    <field name="report_image_url"/>
+                                </tree>
+                            </field>
+                        </page>
                     </notebook>
                     <group>
                         <group>

--- a/dingtalk_report/wizard/dingtalk_report_list.py
+++ b/dingtalk_report/wizard/dingtalk_report_list.py
@@ -55,7 +55,6 @@ class DingTalkReportListTran(models.TransientModel):
                     if result.get('errcode') == 0:
                         result = result.get('result')
                         data_list = result.get('data_list')
-                        print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>',data_list)
                         for data in data_list:
                             # 封装字段数据
                             report_data = dict()

--- a/dingtalk_report/wizard/dingtalk_report_list.py
+++ b/dingtalk_report/wizard/dingtalk_report_list.py
@@ -58,6 +58,7 @@ class DingTalkReportListTran(models.TransientModel):
                         data_list = result.get('data_list')
                         for data in data_list:
                             # 封装字段数据
+                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>',data)
                             report_data = dict()
                             for contents in data.get('contents'):
                                 report_data.update({report_dict.get(contents.get('key')): contents.get('value')})

--- a/dingtalk_report/wizard/dingtalk_report_list.py
+++ b/dingtalk_report/wizard/dingtalk_report_list.py
@@ -58,7 +58,8 @@ class DingTalkReportListTran(models.TransientModel):
                         data_list = result.get('data_list')
                         for data in data_list:
                             # 封装字段数据
-                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>',data)
+                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>fields.datetime.now()',fields.datetime.now())
+                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>fields.date.today()',fields.date.today())
                             report_data = dict()
                             for contents in data.get('contents'):
                                 report_data.update({report_dict.get(contents.get('key')): contents.get('value')})

--- a/dingtalk_report/wizard/dingtalk_report_list.py
+++ b/dingtalk_report/wizard/dingtalk_report_list.py
@@ -18,7 +18,7 @@ class DingTalkReportListTran(models.TransientModel):
     category_id = fields.Many2one(comodel_name='dingtalk.report.category', string=u'系统日志类型')
     report_id = fields.Many2one(comodel_name='dingtalk.report.template', string=u'钉钉日志模板', required=True)
     start_time = fields.Date(string=u'开始时间', required=True)
-    end_time = fields.Date(string=u'结束时间', required=True, default=fields.datetime.now())
+    end_time = fields.Date(string=u'结束时间', required=True, default=fields.Datetime.now())
     emp_ids = fields.Many2many(comodel_name='hr.employee', string=u'员工', domain="[('ding_id', '!=', False)]")
 
     def get_user_report_list(self):
@@ -58,8 +58,6 @@ class DingTalkReportListTran(models.TransientModel):
                         data_list = result.get('data_list')
                         for data in data_list:
                             # 封装字段数据
-                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>fields.datetime.now()',fields.datetime.now())
-                            print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>fields.date.today()',fields.date.today())
                             report_data = dict()
                             for contents in data.get('contents'):
                                 report_data.update({report_dict.get(contents.get('key')): contents.get('value')})

--- a/dingtalk_report/wizard/dingtalk_report_list.xml
+++ b/dingtalk_report/wizard/dingtalk_report_list.xml
@@ -12,8 +12,8 @@
                 <sheet>
                     <group>
                         <field name="report_id" placeholder="请选择日志类型" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
-                        <field name="start_time" widget="datetime"/>
-                        <field name="end_time" widget="datetime"/>
+                        <field name="start_time"/>
+                        <field name="end_time"/>
                         <field name="emp_ids" widget="many2many_tags" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
                     </group>
                 </sheet>

--- a/dingtalk_report/wizard/dingtalk_report_list.xml
+++ b/dingtalk_report/wizard/dingtalk_report_list.xml
@@ -11,7 +11,8 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="report_id" placeholder="请选择日志类型" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
+                        <field name="category_id" placeholder="请选择系统日志类型" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
+                        <field name="report_id" placeholder="请选择钉钉日志模板" domain="[('category_id', '=', category_id)]" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
                         <field name="start_time"/>
                         <field name="end_time"/>
                         <field name="emp_ids" widget="many2many_tags" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>

--- a/dingtalk_report/wizard/dingtalk_report_list.xml
+++ b/dingtalk_report/wizard/dingtalk_report_list.xml
@@ -27,12 +27,12 @@
     </record>
 
     <record id="dingtalk_report_list_tran_action" model="ir.actions.act_window">
-        <field name="name">获取钉钉日志模板</field>
+        <field name="name">获取钉钉日志</field>
         <field name="res_model">dingtalk.report.list.tran</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
     </record>
 
-    <menuitem name="获取用户日志" id="dingtalk_report_list_tran_menu" parent="dingtalk_report_root_menu" sequence="2" action="dingtalk_report_list_tran_action"/>
+    <menuitem name="获取日志" id="dingtalk_report_list_tran_menu" parent="dingtalk_report_root_menu" sequence="2" action="dingtalk_report_list_tran_action"/>
 
 </odoo>


### PR DESCRIPTION
1.修改获取钉钉日志窗口的员工字段为非必填，如该字段不填，则默认获取该日志类型下所有日志。
2.将日志选择时间段改为日期格式。
3.修复未获取日志唯一ID错误，同时在列表视图添加ID显示。
4.修复日志获取时间段超过180天报错。