### PR TITLE
对话框添加默认公司

### DIFF
--- a/dingtalk_mc/wizard/approval_template.py
+++ b/dingtalk_mc/wizard/approval_template.py
@@ -12,7 +12,7 @@ class DingTalkApprovalTemplateTran(models.TransientModel):
     _name = 'dingtalk.approval.template.tran'
     _description = "获取审批模板"
 
-    company_ids = fields.Many2many("res.company", string="选择公司", required=True)
+    company_ids = fields.Many2many("res.company", string="选择公司", required=True, default=lambda self: self.env.ref('base.main_company'))
 
     def get_template(self):
         """

--- a/dingtalk_mc/wizard/callback_get.py
+++ b/dingtalk_mc/wizard/callback_get.py
@@ -12,7 +12,7 @@ class GetCallbackList(models.TransientModel):
     _description = "获取回调列表"
     _rec_name = 'id'
 
-    company_ids = fields.Many2many('res.company', 'dingtalk_get_callback_rel', string="获取的公司", required=True)
+    company_ids = fields.Many2many('res.company', 'dingtalk_get_callback_rel', string="获取的公司", required=True, default=lambda self: self.env.ref('base.main_company'))
 
     def get_callback_list(self):
         for company in self.company_ids:

--- a/dingtalk_mc/wizard/dingtalk_microapp.py
+++ b/dingtalk_mc/wizard/dingtalk_microapp.py
@@ -11,7 +11,7 @@ class DingtalkMicroappWizard(models.TransientModel):
     _name = 'dingtalk.miroapp.list.wizard'
     _description = "获取应用列表向导"
 
-    company_ids = fields.Many2many("res.company", string="选择公司", required=True)
+    company_ids = fields.Many2many("res.company", string="选择公司", required=True, default=lambda self: self.env.ref('base.main_company'))
 
     def get_miroapp_list(self):
         """

--- a/dingtalk_mc/wizard/employee_roster.py
+++ b/dingtalk_mc/wizard/employee_roster.py
@@ -11,7 +11,7 @@ class EmployeeRosterSynchronous(models.TransientModel):
     _name = 'dingtalk.employee.roster.synchronous'
     _description = "智能人事花名册同步"
 
-    company_ids = fields.Many2many("res.company", string="同步的公司", required=True)
+    company_ids = fields.Many2many("res.company", string="同步的公司", required=True, default=lambda self: self.env.ref('base.main_company'))
 
     def start_synchronous_data(self):
         """

--- a/dingtalk_mc/wizard/hr_attendance.py
+++ b/dingtalk_mc/wizard/hr_attendance.py
@@ -15,7 +15,7 @@ class HrAttendanceResultTransient(models.TransientModel):
     _name = 'hr.attendance.tran'
     _description = '获取钉钉考勤结果'
 
-    company_ids = fields.Many2many("res.company", string="公司", required=True)
+    company_ids = fields.Many2many("res.company", string="公司", required=True, default=lambda self: self.env.ref('base.main_company'))
     start_date = fields.Date(string=u'开始日期', required=True, default=fields.Date.context_today)
     stop_date = fields.Date(string=u'结束日期', required=True, default=fields.Date.context_today)
 

--- a/dingtalk_mc/wizard/synchronous.py
+++ b/dingtalk_mc/wizard/synchronous.py
@@ -15,7 +15,8 @@ class DingTalkMcSynchronous(models.TransientModel):
 
     RepeatType = [('name', '以名称判断'), ('id', '以钉钉ID')]
 
-    company_ids = fields.Many2many('res.company', 'dingtalk_mc_companys_rel', string="要同步的公司", required=True)
+    company_ids = fields.Many2many('res.company', 'dingtalk_mc_companys_rel', string="要同步的公司", 
+                                   required=True, default=lambda self: self.env.ref('base.main_company'))
     department = fields.Boolean(string=u'钉钉部门', default=True)
     synchronous_dept_detail = fields.Boolean(string=u'部门详情', default=False)
     repeat_type = fields.Selection(string=u'判断唯一', selection=RepeatType, default='name')


### PR DESCRIPTION
在以下对话框添加默认公司，方便单公司使用：
获取审批对话框，获取回调列表，获取应用列表向导，智能人事花名册同步，获取钉钉考勤结果，组织架构同步