### PR TITLE
修改env.user.company_id 为 env.company，修改后，取到的是当前正在操作的公司，而不是用户的默认公司

### DIFF
--- a/dingtalk_mc/models/dingtalk_chat_robot.py
+++ b/dingtalk_mc/models/dingtalk_chat_robot.py
@@ -47,7 +47,7 @@ class DingTalkRobot(models.Model):
             requests.post(url=res.webhook, headers=headers, data=json.dumps(data), timeout=1)
             # 创建消息日志
             self.env['dingtalk.message.log'].create({
-                'company_id': self.env.user.company_id.id,
+                'company_id': self.env.company.id,
                 'name': "机器人测试连接",
                 'msg_type': "msg",
                 'body': content,
@@ -161,7 +161,7 @@ class DingTalkRobotSendMessage(models.TransientModel):
                 message = 'feed_card消息'
                 # 创建消息日志
             self.env['dingtalk.message.log'].create({
-                'company_id': self.env.user.company_id.id,
+                'company_id': self.env.company.id,
                 'name': "群机器人发送消息",
                 'msg_type': "msg",
                 'body': message,

--- a/dingtalk_mc/models/dingtalk_message.py
+++ b/dingtalk_mc/models/dingtalk_message.py
@@ -45,7 +45,7 @@ class DingTalkSendChatMessage(models.TransientModel):
             result = client.chat.send(ding_chat.chat_id, msg)
             # 创建消息日志
             self.env['dingtalk.message.log'].create({
-                'company_id': self.env.user.company_id.id,
+                'company_id': self.env.company.id,
                 'name': "发送群消息",
                 'msg_type': "chat",
                 'body': self.message,

--- a/dingtalk_mc/tools/dingtalk_approval.py
+++ b/dingtalk_mc/tools/dingtalk_approval.py
@@ -17,7 +17,7 @@ def approval_result(self):
     """
     # 获取钉钉审批配置
     model_id = self.env['ir.model'].with_user(SUPERUSER_ID).search([('model', '=', self._name)]).id
-    domain = [('oa_model_id', '=', model_id), ('company_id', '=', self.env.user.company_id.id)]
+    domain = [('oa_model_id', '=', model_id), ('company_id', '=', self.env.company.id)]
     approval = self.env['dingtalk.approval.control'].with_user(SUPERUSER_ID).search(domain, limit=1)
     _logger.info("提交'%s'单据至钉钉进行审批..." % approval.name)
     # 钉钉审批模型编码
@@ -46,7 +46,7 @@ def approval_result(self):
             'cc_position': cc_type     # 抄送时间
         })
     # ----提交至钉钉---
-    client = dt.get_client(self, dt.get_dingtalk_config(self, self.env.user.company_id))
+    client = dt.get_client(self, dt.get_dingtalk_config(self, self.env.company))
     try:
         url = 'topapi/processinstance/create'
         result = client.post(url, data)

--- a/dingtalk_mc/tools/ir_ui_view.py
+++ b/dingtalk_mc/tools/ir_ui_view.py
@@ -138,7 +138,7 @@ def view_get_approval_flow(self, view_type, result):
     if flow_obj is None:
         return
     model_id = self.env['ir.model'].with_user(SUPERUSER_ID).search([('model', '=', self._name)]).id
-    domain = [('company_id', '=', self.env.user.company_id.id), ('oa_model_id', '=', model_id)]
+    domain = [('company_id', '=', self.env.company.id), ('oa_model_id', '=', model_id)]
     flows = flow_obj.with_context(active_test=False).with_user(SUPERUSER_ID).search(domain)
     if not flows:
         return

--- a/dingtalk_mc/tools/odoo_model.py
+++ b/dingtalk_mc/tools/odoo_model.py
@@ -68,7 +68,7 @@ def dingtalk_approval_write(self, vals):
         return
     for res in self:
         model_id = self.env['ir.model'].with_user(SUPERUSER_ID).search([('model', '=', res._name)]).id
-        flows = res_state_obj.with_user(SUPERUSER_ID).search([('oa_model_id', '=', model_id), ('company_id', '=', self.env.user.company_id.id)])
+        flows = res_state_obj.with_user(SUPERUSER_ID).search([('oa_model_id', '=', model_id), ('company_id', '=', self.env.company.id)])
         if not flows:
             continue
         if not flows[0].is_ing_write and res.dd_approval_state == 'approval':
@@ -99,7 +99,7 @@ def dingtalk_approval_unlink(self):
         return
     for res in self:
         model_id = self.env['ir.model'].with_user(SUPERUSER_ID).search([('model', '=', res._name)]).id
-        flows = res_state_obj.with_user(SUPERUSER_ID).search([('oa_model_id', '=', model_id), ('company_id', '=', self.env.user.company_id.id)])
+        flows = res_state_obj.with_user(SUPERUSER_ID).search([('oa_model_id', '=', model_id), ('company_id', '=', self.env.company.id)])
         if not flows:
             continue
         if res.dd_approval_state != 'draft':

--- a/dingtalk_mc/wizard/synchronous.py
+++ b/dingtalk_mc/wizard/synchronous.py
@@ -16,7 +16,7 @@ class DingTalkMcSynchronous(models.TransientModel):
     RepeatType = [('name', '以名称判断'), ('id', '以钉钉ID')]
 
     company_ids = fields.Many2many('res.company', 'dingtalk_mc_companys_rel', string="要同步的公司", required=True,
-                                   default=lambda self: [(6, 0, [self.env.user.company_id.id])])
+                                   default=lambda self: [(6, 0, [self.env.company.id])])
     department = fields.Boolean(string=u'钉钉部门', default=True)
     synchronous_dept_detail = fields.Boolean(string=u'部门详情', default=False)
     repeat_type = fields.Selection(string=u'判断唯一', selection=RepeatType, default='id')
@@ -186,7 +186,7 @@ class DingTalkMCSynchronousPartner(models.TransientModel):
     _rec_name = 'id'
 
     company_ids = fields.Many2many('res.company', 'dingtalk_mc_partner_companys_rel', string="要同步的公司", required=True,
-                                   default=lambda self: [(6, 0, [self.env.user.company_id.id])])
+                                   default=lambda self: [(6, 0, [self.env.company.id])])
 
     def start_synchronous_partner(self):
         self.ensure_one()
@@ -285,7 +285,7 @@ class CreateResUser(models.TransientModel):
             if res.is_all:
                 domain = [
                     ('user_id', '=', False),
-                    ('company_id', '=', self.env.user.company_id.id),
+                    ('company_id', '=', self.env.company.id),
                     ('ding_id', '!=', False)
                 ]
                 emps = self.env['hr.employee'].search(domain)


### PR DESCRIPTION
在取当前用户公司时，原设计使用的是env.user.company_id，这个取到的是用户的默认公司。
但在多公司操作环境下，用户可以通过多公司选择插件，切换当前的操作公司；此项切换后，上面取值并未切换，造成实际公司与用户期望不一致。
而改为env.company后，可以解决上面这个问题。